### PR TITLE
Manage discord spoilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ cache:
 
 script:
   - yarn run test
+  - yarn run lint

--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ toHTML('This **is** a __test__', options);
 * `escapeHTML`: boolean (default: true), if it should escape HTML
 * `discordOnly`: boolean (default: false), if it should only parse the discord-specific stuff
 * `discordCallback`: object, callbacks used for discord parsing. Each receive an object with different properties, and are expected to return an HTML escaped string
-  * `user`: (`id`: number) user mentions "@someperson"
-  * `channel`: (`id`: number) channel mentions "#somechannel"
-  * `role`: (`id`: number) role mentions "@somerole"
-  * `emoji`: (`animated`: boolean, `name`: string, `id`: number) emojis ":emote":
+  * `user`: (`id`: string) user mentions "@someperson"
+  * `channel`: (`id`: string) channel mentions "#somechannel"
+  * `role`: (`id`: string) role mentions "@somerole"
+  * `emoji`: (`animated`: boolean, `name`: string, `id`: string) emojis ":emote":
   * `everyone`: () everyone mention "@everyone"
   * `here`: () here mention "@here"
+  * `spoiler`: (`content`: string) spoiler parsing "||spoiler||". `content` is already HTML-escaped (if setting is set)
 
 Example:
 

--- a/index.js
+++ b/index.js
@@ -135,18 +135,6 @@ const rules = {
 	br: Object.assign({ }, markdown.defaultRules.br, {
 		match: markdown.anyScopeRegex(/^\n/),
 	}),
-	spoiler: {
-		order: 0,
-		match: source => /^{{([^\n]+)}}/.exec(source),
-		parse: function(capture, parse, state) {
-			return {
-				content: parse(capture[1], state)
-			};
-		},
-		html: function(node, output, state) {
-			return htmlTag('span', output(node.content, state), { class: 'd-spoiler' }, state);
-		}
-	}
 };
 
 const rulesDiscord = {

--- a/index.js
+++ b/index.js
@@ -34,8 +34,7 @@ const discordCallbackDefaults = {
 	role: node => '&' + node.id,
 	emoji: node => ':' + markdown.sanitizeText(node.name) + ':',
 	everyone: () => '@everyone',
-	here: () => '@here',
-	spoiler: node => '<spoiler>' + node.content + '</spoiler>'
+	here: () => '@here'
 };
 
 let discordCallback = discordCallbackDefaults;
@@ -69,9 +68,7 @@ const rules = {
 			};
 		},
 		html: function(node, output, state) {
-			return output(node.preContent, state) + discordCallback.spoiler({
-				content: output(node.content, state)
-			});
+			return output(node.preContent, state) + htmlTag('span', output(node.content, state), { class: 'd-spoiler' }, state);
 		}
 	},
 	newline: markdown.defaultRules.newline,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,34 +1,67 @@
 {
 	"name": "discord-markdown",
-	"version": "1.0.0",
+	"version": "2.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			}
+		},
 		"abab": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
 			"dev": true
 		},
 		"acorn": {
-			"version": "4.0.13",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-			"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+			"version": "6.0.6",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.6.tgz",
+			"integrity": "sha512-5M3G/A4uBSMIlfJ+h9W125vJvPFH/zirISsW5qfxF5YzEvXJCtolLoQvM5yZft0DvMcUrPGKPOlgEu55I6iUtA==",
 			"dev": true
 		},
 		"acorn-globals": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
+			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^4.0.4"
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
 			}
 		},
+		"acorn-jsx": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+			"dev": true
+		},
+		"acorn-walk": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+			"dev": true
+		},
 		"ajv": {
-			"version": "6.5.5",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-			"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+			"integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
@@ -38,15 +71,15 @@
 			}
 		},
 		"ansi-escapes": {
-			"version": "3.1.0",
-			"resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
 			"dev": true
 		},
 		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 			"dev": true
 		},
 		"ansi-styles": {
@@ -107,6 +140,15 @@
 								"is-extendable": "^0.1.0"
 							}
 						}
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
 					}
 				},
 				"expand-brackets": {
@@ -341,6 +383,12 @@
 						"snapdragon": "^0.8.1",
 						"to-regex": "^3.0.2"
 					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
 				}
 			}
 		},
@@ -385,7 +433,7 @@
 		},
 		"array-equal": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
 			"dev": true
 		},
@@ -437,6 +485,12 @@
 				"lodash": "^4.17.10"
 			}
 		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"dev": true
+		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -472,6 +526,12 @@
 				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -480,7 +540,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -491,9 +551,15 @@
 						"supports-color": "^2.0.0"
 					}
 				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
@@ -533,6 +599,23 @@
 				"private": "^0.1.8",
 				"slash": "^1.0.0",
 				"source-map": "^0.5.7"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
 			}
 		},
 		"babel-generator": {
@@ -562,13 +645,13 @@
 			}
 		},
 		"babel-jest": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
-			"integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
+			"integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "^4.0.0",
-				"babel-preset-jest": "^21.2.0"
+				"babel-plugin-istanbul": "^4.1.6",
+				"babel-preset-jest": "^23.2.0"
 			}
 		},
 		"babel-messages": {
@@ -582,7 +665,7 @@
 		},
 		"babel-plugin-istanbul": {
 			"version": "4.1.6",
-			"resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"dev": true,
 			"requires": {
@@ -593,24 +676,24 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz",
-			"integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
+			"integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
 			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
-			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
 			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
 			"dev": true
 		},
 		"babel-preset-jest": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz",
-			"integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
+			"integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^21.2.0",
+				"babel-plugin-jest-hoist": "^23.2.0",
 				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
 			}
 		},
@@ -667,6 +750,29 @@
 				"globals": "^9.18.0",
 				"invariant": "^2.2.2",
 				"lodash": "^4.17.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"globals": {
+					"version": "9.18.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
 			}
 		},
 		"babel-types": {
@@ -790,6 +896,12 @@
 				"repeat-element": "^1.1.2"
 			}
 		},
+		"browser-process-hrtime": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+			"dev": true
+		},
 		"browser-resolve": {
 			"version": "1.11.3",
 			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
@@ -807,6 +919,12 @@
 			"requires": {
 				"node-int64": "^0.4.0"
 			}
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
@@ -840,9 +958,9 @@
 			}
 		},
 		"callsites": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+			"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
 			"dev": true
 		},
 		"camelcase": {
@@ -867,9 +985,9 @@
 			"dev": true
 		},
 		"chalk": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
@@ -877,10 +995,22 @@
 				"supports-color": "^5.3.0"
 			}
 		},
+		"chardet": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"dev": true
+		},
 		"ci-info": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
 			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+			"dev": true
+		},
+		"circular-json": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
 			"dev": true
 		},
 		"class-utils": {
@@ -912,38 +1042,37 @@
 				}
 			}
 		},
-		"cliui": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wrap-ansi": "^2.0.0"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
+				"restore-cursor": "^2.0.0"
 			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
+		},
+		"cliui": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"dev": true,
+			"requires": {
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"code-point-at": {
 			"version": "1.1.0",
@@ -1004,12 +1133,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"content-type-parser": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
-			"dev": true
-		},
 		"convert-source-map": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -1026,9 +1149,9 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
+			"integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -1038,12 +1161,14 @@
 			"dev": true
 		},
 		"cross-spawn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^4.0.1",
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
@@ -1055,9 +1180,9 @@
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "0.2.37",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
+			"integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
 			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
@@ -1072,13 +1197,37 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
-		"debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+		"data-urls": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
 			"dev": true,
 			"requires": {
-				"ms": "2.0.0"
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.2.0",
+				"whatwg-url": "^7.0.0"
+			},
+			"dependencies": {
+				"whatwg-url": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
+			}
+		},
+		"debug": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"dev": true,
+			"requires": {
+				"ms": "^2.1.1"
 			}
 		},
 		"decamelize": {
@@ -1106,6 +1255,15 @@
 			"dev": true,
 			"requires": {
 				"strip-bom": "^2.0.0"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
+			"requires": {
+				"object-keys": "^1.0.12"
 			}
 		},
 		"define-property": {
@@ -1176,11 +1334,35 @@
 				"repeating": "^2.0.0"
 			}
 		},
+		"detect-newline": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"dev": true
+		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
+		},
+		"doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2"
+			}
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"dev": true,
+			"requires": {
+				"webidl-conversions": "^4.0.2"
+			}
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
@@ -1192,15 +1374,6 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"errno": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-			"dev": true,
-			"requires": {
-				"prr": "~1.0.1"
-			}
-		},
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1208,6 +1381,31 @@
 			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.2.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
 			}
 		},
 		"escape-string-regexp": {
@@ -1244,11 +1442,107 @@
 				}
 			}
 		},
+		"eslint": {
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.1.tgz",
+			"integrity": "sha512-54NV+JkTpTu0d8+UYSA8mMKAG4XAsaOrozA9rCW7tgneg1mevcL7wIotPC+fZ0SkWwdhNqoXoxnQCTBp7UvTsg==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"ajv": "^6.5.3",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.5",
+				"debug": "^4.0.1",
+				"doctrine": "^2.1.0",
+				"eslint-scope": "^4.0.0",
+				"eslint-utils": "^1.3.1",
+				"eslint-visitor-keys": "^1.0.0",
+				"espree": "^5.0.0",
+				"esquery": "^1.0.1",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^2.0.0",
+				"functional-red-black-tree": "^1.0.1",
+				"glob": "^7.1.2",
+				"globals": "^11.7.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.0.0",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^6.1.0",
+				"js-yaml": "^3.12.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.5",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"path-is-inside": "^1.0.2",
+				"pluralize": "^7.0.0",
+				"progress": "^2.0.0",
+				"regexpp": "^2.0.1",
+				"semver": "^5.5.1",
+				"strip-ansi": "^4.0.0",
+				"strip-json-comments": "^2.0.1",
+				"table": "^5.0.2",
+				"text-table": "^0.2.0"
+			}
+		},
+		"eslint-scope": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+			"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+			"dev": true,
+			"requires": {
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
+			}
+		},
+		"eslint-utils": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+			"integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+			"dev": true
+		},
+		"eslint-visitor-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
+		},
+		"espree": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
+			"integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+			"dev": true,
+			"requires": {
+				"acorn": "^6.0.2",
+				"acorn-jsx": "^5.0.0",
+				"eslint-visitor-keys": "^1.0.0"
+			}
+		},
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true
+		},
+		"esquery": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^4.0.0"
+			}
+		},
+		"esrecurse": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^4.1.0"
+			}
 		},
 		"estraverse": {
 			"version": "4.2.0",
@@ -1284,7 +1578,26 @@
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				}
 			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
@@ -1305,17 +1618,17 @@
 			}
 		},
 		"expect": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-21.2.1.tgz",
-			"integrity": "sha512-orfQQqFRTX0jH7znRIGi8ZMR8kTNpXklTTz8+HGTpmTKZo3Occ6JNB5FXMb8cRuiiC/GyDqsr30zUa66ACYlYw==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
+			"integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
-				"jest-diff": "^21.2.1",
-				"jest-get-type": "^21.2.0",
-				"jest-matcher-utils": "^21.2.1",
-				"jest-message-util": "^21.2.1",
-				"jest-regex-util": "^21.2.0"
+				"jest-diff": "^23.6.0",
+				"jest-get-type": "^22.1.0",
+				"jest-matcher-utils": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-regex-util": "^23.3.0"
 			}
 		},
 		"extend": {
@@ -1343,6 +1656,17 @@
 						"is-plain-object": "^2.0.4"
 					}
 				}
+			}
+		},
+		"external-editor": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+			"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+			"dev": true,
+			"requires": {
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
+				"tmp": "^0.0.33"
 			}
 		},
 		"extglob": {
@@ -1387,6 +1711,25 @@
 				"bser": "^2.0.0"
 			}
 		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			}
+		},
+		"file-entry-cache": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
+			"requires": {
+				"flat-cache": "^1.2.1",
+				"object-assign": "^4.0.1"
+			}
+		},
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -1423,6 +1766,18 @@
 			"dev": true,
 			"requires": {
 				"locate-path": "^2.0.0"
+			}
+		},
+		"flat-cache": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+			"integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+			"dev": true,
+			"requires": {
+				"circular-json": "^0.3.1",
+				"graceful-fs": "^4.1.2",
+				"rimraf": "~2.6.2",
+				"write": "^0.2.1"
 			}
 		},
 		"for-in": {
@@ -1473,9 +1828,9 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+			"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -1502,7 +1857,7 @@
 					"optional": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.4",
+					"version": "1.1.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -1528,7 +1883,7 @@
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -1567,7 +1922,7 @@
 					}
 				},
 				"deep-extend": {
-					"version": "0.5.1",
+					"version": "0.6.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -1616,7 +1971,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -1636,12 +1991,12 @@
 					"optional": true
 				},
 				"iconv-lite": {
-					"version": "0.4.21",
+					"version": "0.4.24",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"ignore-walk": {
@@ -1706,17 +2061,17 @@
 					"optional": true
 				},
 				"minipass": {
-					"version": "2.2.4",
+					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
-					"version": "1.1.0",
+					"version": "1.2.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -1740,7 +2095,7 @@
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.0",
+					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -1751,18 +2106,18 @@
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.0",
+					"version": "0.10.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
 						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
+						"needle": "^2.2.1",
 						"nopt": "^4.0.1",
 						"npm-packlist": "^1.1.6",
 						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
+						"rc": "^1.2.7",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
 						"tar": "^4"
@@ -1779,13 +2134,13 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.3",
+					"version": "1.0.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.1.10",
+					"version": "1.2.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -1862,12 +2217,12 @@
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.7",
+					"version": "1.2.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
+						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -1897,16 +2252,16 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.1",
+					"version": "5.1.2",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -1924,7 +2279,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.5.0",
+					"version": "5.6.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -1977,17 +2332,17 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.1",
+					"version": "4.4.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
+						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
 						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
 				},
@@ -1998,12 +2353,12 @@
 					"optional": true
 				},
 				"wide-align": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"wrappy": {
@@ -2013,12 +2368,24 @@
 					"optional": true
 				},
 				"yallist": {
-					"version": "3.0.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				}
 			}
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "1.0.3",
@@ -2028,7 +2395,7 @@
 		},
 		"get-stream": {
 			"version": "3.0.0",
-			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 			"dev": true
 		},
@@ -2081,9 +2448,9 @@
 			}
 		},
 		"globals": {
-			"version": "9.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"version": "11.10.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+			"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
 			"dev": true
 		},
 		"graceful-fs": {
@@ -2134,6 +2501,15 @@
 				"har-schema": "^2.0.0"
 			}
 		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
 		"has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2141,12 +2517,26 @@
 			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				}
 			}
 		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
 			"dev": true
 		},
 		"has-value": {
@@ -2259,6 +2649,32 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
+		"ignore": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+			"dev": true
+		},
+		"import-fresh": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+			"integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+			"dev": true,
+			"requires": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			}
+		},
+		"import-local": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"dev": true,
+			"requires": {
+				"pkg-dir": "^2.0.0",
+				"resolve-cwd": "^2.0.0"
+			}
+		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2280,6 +2696,44 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 			"dev": true
+		},
+		"inquirer": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+			"integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^3.2.0",
+				"chalk": "^2.4.2",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^3.0.3",
+				"figures": "^2.0.0",
+				"lodash": "^4.17.11",
+				"mute-stream": "0.0.7",
+				"run-async": "^2.2.0",
+				"rxjs": "^6.4.0",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^5.0.0",
+				"through": "^2.3.6"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+					"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.0.0"
+					}
+				}
+			}
 		},
 		"invariant": {
 			"version": "2.2.4",
@@ -2319,12 +2773,18 @@
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
 				"builtin-modules": "^1.0.0"
 			}
+		},
+		"is-callable": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"dev": true
 		},
 		"is-ci": {
 			"version": "1.2.1",
@@ -2343,6 +2803,12 @@
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -2400,13 +2866,16 @@
 			}
 		},
 		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
+		},
+		"is-generator-fn": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+			"dev": true
 		},
 		"is-glob": {
 			"version": "2.0.1",
@@ -2455,11 +2924,35 @@
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
 			"dev": true
 		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.1"
+			}
+		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 			"dev": true
+		},
+		"is-symbol": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -2605,12 +3098,6 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
 				}
 			}
 		},
@@ -2624,251 +3111,318 @@
 			}
 		},
 		"jest": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-21.2.1.tgz",
-			"integrity": "sha512-mXN0ppPvWYoIcC+R+ctKxAJ28xkt/Z5Js875padm4GbgUn6baeR5N4Ng6LjatIRpUQDZVJABT7Y4gucFjPryfw==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
+			"integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
 			"dev": true,
 			"requires": {
-				"jest-cli": "^21.2.1"
+				"import-local": "^1.0.0",
+				"jest-cli": "^23.6.0"
 			},
 			"dependencies": {
 				"jest-cli": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.2.1.tgz",
-					"integrity": "sha512-T1BzrbFxDIW/LLYQqVfo94y/hhaj1NzVQkZgBumAC+sxbjMROI7VkihOdxNR758iYbQykL2ZOWUBurFgkQrzdg==",
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
+					"integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
 					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
 						"glob": "^7.1.2",
 						"graceful-fs": "^4.1.11",
+						"import-local": "^1.0.0",
 						"is-ci": "^1.0.10",
-						"istanbul-api": "^1.1.1",
-						"istanbul-lib-coverage": "^1.0.1",
-						"istanbul-lib-instrument": "^1.4.2",
-						"istanbul-lib-source-maps": "^1.1.0",
-						"jest-changed-files": "^21.2.0",
-						"jest-config": "^21.2.1",
-						"jest-environment-jsdom": "^21.2.1",
-						"jest-haste-map": "^21.2.0",
-						"jest-message-util": "^21.2.1",
-						"jest-regex-util": "^21.2.0",
-						"jest-resolve-dependencies": "^21.2.0",
-						"jest-runner": "^21.2.1",
-						"jest-runtime": "^21.2.1",
-						"jest-snapshot": "^21.2.1",
-						"jest-util": "^21.2.1",
+						"istanbul-api": "^1.3.1",
+						"istanbul-lib-coverage": "^1.2.0",
+						"istanbul-lib-instrument": "^1.10.1",
+						"istanbul-lib-source-maps": "^1.2.4",
+						"jest-changed-files": "^23.4.2",
+						"jest-config": "^23.6.0",
+						"jest-environment-jsdom": "^23.4.0",
+						"jest-get-type": "^22.1.0",
+						"jest-haste-map": "^23.6.0",
+						"jest-message-util": "^23.4.0",
+						"jest-regex-util": "^23.3.0",
+						"jest-resolve-dependencies": "^23.6.0",
+						"jest-runner": "^23.6.0",
+						"jest-runtime": "^23.6.0",
+						"jest-snapshot": "^23.6.0",
+						"jest-util": "^23.4.0",
+						"jest-validate": "^23.6.0",
+						"jest-watcher": "^23.4.0",
+						"jest-worker": "^23.2.0",
 						"micromatch": "^2.3.11",
-						"node-notifier": "^5.0.2",
-						"pify": "^3.0.0",
+						"node-notifier": "^5.2.1",
+						"prompts": "^0.1.9",
+						"realpath-native": "^1.0.0",
+						"rimraf": "^2.5.4",
 						"slash": "^1.0.0",
 						"string-length": "^2.0.0",
 						"strip-ansi": "^4.0.0",
 						"which": "^1.2.12",
-						"worker-farm": "^1.3.1",
-						"yargs": "^9.0.0"
+						"yargs": "^11.0.0"
 					}
 				}
 			}
 		},
 		"jest-changed-files": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.2.0.tgz",
-			"integrity": "sha512-+lCNP1IZLwN1NOIvBcV5zEL6GENK6TXrDj4UxWIeLvIsIDa+gf6J7hkqsW2qVVt/wvH65rVvcPwqXdps5eclTQ==",
+			"version": "23.4.2",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz",
+			"integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
 			"dev": true,
 			"requires": {
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz",
-			"integrity": "sha512-fJru5HtlD/5l2o25eY9xT0doK3t2dlglrqoGpbktduyoI0T5CwuB++2YfoNZCrgZipTwPuAGonYv0q7+8yDc/A==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz",
+			"integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
 			"dev": true,
 			"requires": {
+				"babel-core": "^6.0.0",
+				"babel-jest": "^23.6.0",
 				"chalk": "^2.0.1",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^21.2.1",
-				"jest-environment-node": "^21.2.1",
-				"jest-get-type": "^21.2.0",
-				"jest-jasmine2": "^21.2.1",
-				"jest-regex-util": "^21.2.0",
-				"jest-resolve": "^21.2.0",
-				"jest-util": "^21.2.1",
-				"jest-validate": "^21.2.1",
-				"pretty-format": "^21.2.1"
+				"jest-environment-jsdom": "^23.4.0",
+				"jest-environment-node": "^23.4.0",
+				"jest-get-type": "^22.1.0",
+				"jest-jasmine2": "^23.6.0",
+				"jest-regex-util": "^23.3.0",
+				"jest-resolve": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"jest-validate": "^23.6.0",
+				"micromatch": "^2.3.11",
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-diff": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
-			"integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz",
+			"integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"diff": "^3.2.0",
-				"jest-get-type": "^21.2.0",
-				"pretty-format": "^21.2.1"
+				"jest-get-type": "^22.1.0",
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-docblock": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-			"integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-			"dev": true
-		},
-		"jest-environment-jsdom": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz",
-			"integrity": "sha512-mecaeNh0eWmzNrUNMWARysc0E9R96UPBamNiOCYL28k7mksb1d0q6DD38WKP7ABffjnXyUWJPVaWRgUOivwXwg==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
+			"integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^21.2.0",
-				"jest-util": "^21.2.1",
-				"jsdom": "^9.12.0"
+				"detect-newline": "^2.1.0"
+			}
+		},
+		"jest-each": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz",
+			"integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"pretty-format": "^23.6.0"
+			}
+		},
+		"jest-environment-jsdom": {
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
+			"integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
+			"dev": true,
+			"requires": {
+				"jest-mock": "^23.2.0",
+				"jest-util": "^23.4.0",
+				"jsdom": "^11.5.1"
 			}
 		},
 		"jest-environment-node": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.2.1.tgz",
-			"integrity": "sha512-R211867wx9mVBVHzrjGRGTy5cd05K7eqzQl/WyZixR/VkJ4FayS8qkKXZyYnwZi6Rxo6WEV81cDbiUx/GfuLNw==",
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz",
+			"integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^21.2.0",
-				"jest-util": "^21.2.1"
+				"jest-mock": "^23.2.0",
+				"jest-util": "^23.4.0"
 			}
 		},
 		"jest-get-type": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
-			"integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz",
-			"integrity": "sha512-5LhsY/loPH7wwOFRMs+PT4aIAORJ2qwgbpMFlbWbxfN0bk3ZCwxJ530vrbSiTstMkYLao6JwBkLhCJ5XbY7ZHw==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz",
+			"integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
 			"dev": true,
 			"requires": {
 				"fb-watchman": "^2.0.0",
 				"graceful-fs": "^4.1.11",
-				"jest-docblock": "^21.2.0",
+				"invariant": "^2.2.4",
+				"jest-docblock": "^23.2.0",
+				"jest-serializer": "^23.0.1",
+				"jest-worker": "^23.2.0",
 				"micromatch": "^2.3.11",
-				"sane": "^2.0.0",
-				"worker-farm": "^1.3.1"
+				"sane": "^2.0.0"
 			}
 		},
 		"jest-jasmine2": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz",
-			"integrity": "sha512-lw8FXXIEekD+jYNlStfgNsUHpfMWhWWCgHV7n0B7mA/vendH7vBFs8xybjQsDzJSduptBZJHqQX9SMssya9+3A==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz",
+			"integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
 			"dev": true,
 			"requires": {
+				"babel-traverse": "^6.0.0",
 				"chalk": "^2.0.1",
-				"expect": "^21.2.1",
-				"graceful-fs": "^4.1.11",
-				"jest-diff": "^21.2.1",
-				"jest-matcher-utils": "^21.2.1",
-				"jest-message-util": "^21.2.1",
-				"jest-snapshot": "^21.2.1",
-				"p-cancelable": "^0.3.0"
+				"co": "^4.6.0",
+				"expect": "^23.6.0",
+				"is-generator-fn": "^1.0.0",
+				"jest-diff": "^23.6.0",
+				"jest-each": "^23.6.0",
+				"jest-matcher-utils": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-snapshot": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"pretty-format": "^23.6.0"
+			}
+		},
+		"jest-leak-detector": {
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz",
+			"integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
+			"dev": true,
+			"requires": {
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
-			"integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
+			"integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"jest-get-type": "^21.2.0",
-				"pretty-format": "^21.2.1"
+				"jest-get-type": "^22.1.0",
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-message-util": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz",
-			"integrity": "sha512-EbC1X2n0t9IdeMECJn2BOg7buOGivCvVNjqKMXTzQOu7uIfLml+keUfCALDh8o4rbtndIeyGU8/BKfoTr/LVDQ==",
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz",
+			"integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
 			"dev": true,
 			"requires": {
+				"@babel/code-frame": "^7.0.0-beta.35",
 				"chalk": "^2.0.1",
 				"micromatch": "^2.3.11",
-				"slash": "^1.0.0"
+				"slash": "^1.0.0",
+				"stack-utils": "^1.0.1"
 			}
 		},
 		"jest-mock": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.2.0.tgz",
-			"integrity": "sha512-aZDfyVf0LEoABWiY6N0d+O963dUQSyUa4qgzurHR3TBDPen0YxKCJ6l2i7lQGh1tVdsuvdrCZ4qPj+A7PievCw==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
+			"integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=",
 			"dev": true
 		},
 		"jest-regex-util": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz",
-			"integrity": "sha512-BKQ1F83EQy0d9Jen/mcVX7D+lUt2tthhK/2gDWRgLDJRNOdRgSp1iVqFxP8EN1ARuypvDflRfPzYT8fQnoBQFQ==",
+			"version": "23.3.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",
+			"integrity": "sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U=",
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.2.0.tgz",
-			"integrity": "sha512-vefQ/Lr+VdNvHUZFQXWtOqHX3HEdOc2MtSahBO89qXywEbUxGPB9ZLP9+BHinkxb60UT2Q/tTDOS6rYc6Mwigw==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz",
+			"integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
 			"dev": true,
 			"requires": {
-				"browser-resolve": "^1.11.2",
+				"browser-resolve": "^1.11.3",
 				"chalk": "^2.0.1",
-				"is-builtin-module": "^1.0.0"
+				"realpath-native": "^1.0.0"
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz",
-			"integrity": "sha512-ok8ybRFU5ScaAcfufIQrCbdNJSRZ85mkxJ1EhUp8Bhav1W1/jv/rl1Q6QoVQHObNxmKnbHVKrfLZbCbOsXQ+bQ==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz",
+			"integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
 			"dev": true,
 			"requires": {
-				"jest-regex-util": "^21.2.0"
+				"jest-regex-util": "^23.3.0",
+				"jest-snapshot": "^23.6.0"
 			}
 		},
 		"jest-runner": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.2.1.tgz",
-			"integrity": "sha512-Anb72BOQlHqF/zETqZ2K20dbYsnqW/nZO7jV8BYENl+3c44JhMrA8zd1lt52+N7ErnsQMd2HHKiVwN9GYSXmrg==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz",
+			"integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
 			"dev": true,
 			"requires": {
-				"jest-config": "^21.2.1",
-				"jest-docblock": "^21.2.0",
-				"jest-haste-map": "^21.2.0",
-				"jest-jasmine2": "^21.2.1",
-				"jest-message-util": "^21.2.1",
-				"jest-runtime": "^21.2.1",
-				"jest-util": "^21.2.1",
-				"pify": "^3.0.0",
-				"throat": "^4.0.0",
-				"worker-farm": "^1.3.1"
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.11",
+				"jest-config": "^23.6.0",
+				"jest-docblock": "^23.2.0",
+				"jest-haste-map": "^23.6.0",
+				"jest-jasmine2": "^23.6.0",
+				"jest-leak-detector": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-runtime": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"jest-worker": "^23.2.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^4.0.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"source-map-support": {
+					"version": "0.5.10",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+					"integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+					"dev": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				}
 			}
 		},
 		"jest-runtime": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz",
-			"integrity": "sha512-6omlpA3+NSE+rHwD0PQjNEjZeb2z+oRmuehMfM1tWQVum+E0WV3pFt26Am0DUfQkkPyTABvxITRjCUclYgSOsA==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz",
+			"integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
 			"dev": true,
 			"requires": {
 				"babel-core": "^6.0.0",
-				"babel-jest": "^21.2.0",
-				"babel-plugin-istanbul": "^4.0.0",
+				"babel-plugin-istanbul": "^4.1.6",
 				"chalk": "^2.0.1",
 				"convert-source-map": "^1.4.0",
+				"exit": "^0.1.2",
+				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.1.11",
-				"jest-config": "^21.2.1",
-				"jest-haste-map": "^21.2.0",
-				"jest-regex-util": "^21.2.0",
-				"jest-resolve": "^21.2.0",
-				"jest-util": "^21.2.1",
-				"json-stable-stringify": "^1.0.1",
+				"jest-config": "^23.6.0",
+				"jest-haste-map": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-regex-util": "^23.3.0",
+				"jest-resolve": "^23.6.0",
+				"jest-snapshot": "^23.6.0",
+				"jest-util": "^23.4.0",
+				"jest-validate": "^23.6.0",
 				"micromatch": "^2.3.11",
+				"realpath-native": "^1.0.0",
 				"slash": "^1.0.0",
 				"strip-bom": "3.0.0",
 				"write-file-atomic": "^2.1.0",
-				"yargs": "^9.0.0"
+				"yargs": "^11.0.0"
 			},
 			"dependencies": {
 				"strip-bom": {
@@ -2879,57 +3433,102 @@
 				}
 			}
 		},
+		"jest-serializer": {
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
+			"integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
+			"dev": true
+		},
 		"jest-snapshot": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz",
-			"integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz",
+			"integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
 			"dev": true,
 			"requires": {
+				"babel-types": "^6.0.0",
 				"chalk": "^2.0.1",
-				"jest-diff": "^21.2.1",
-				"jest-matcher-utils": "^21.2.1",
+				"jest-diff": "^23.6.0",
+				"jest-matcher-utils": "^23.6.0",
+				"jest-message-util": "^23.4.0",
+				"jest-resolve": "^23.6.0",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^21.2.1"
+				"pretty-format": "^23.6.0",
+				"semver": "^5.5.0"
 			}
 		},
 		"jest-util": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz",
-			"integrity": "sha512-r20W91rmHY3fnCoO7aOAlyfC51x2yeV3xF+prGsJAUsYhKeV670ZB8NO88Lwm7ASu8SdH0S+U+eFf498kjhA4g==",
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz",
+			"integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
 			"dev": true,
 			"requires": {
 				"callsites": "^2.0.0",
 				"chalk": "^2.0.1",
 				"graceful-fs": "^4.1.11",
-				"jest-message-util": "^21.2.1",
-				"jest-mock": "^21.2.0",
-				"jest-validate": "^21.2.1",
-				"mkdirp": "^0.5.1"
+				"is-ci": "^1.0.10",
+				"jest-message-util": "^23.4.0",
+				"mkdirp": "^0.5.1",
+				"slash": "^1.0.0",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"callsites": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
 			}
 		},
 		"jest-validate": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
-			"integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
+			"integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"jest-get-type": "^21.2.0",
+				"jest-get-type": "^22.1.0",
 				"leven": "^2.1.0",
-				"pretty-format": "^21.2.1"
+				"pretty-format": "^23.6.0"
+			}
+		},
+		"jest-watcher": {
+			"version": "23.4.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz",
+			"integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"string-length": "^2.0.0"
+			}
+		},
+		"jest-worker": {
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
+			"integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
+			"dev": true,
+			"requires": {
+				"merge-stream": "^1.0.1"
 			}
 		},
 		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"version": "3.12.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+			"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -2943,35 +3542,50 @@
 			"dev": true
 		},
 		"jsdom": {
-			"version": "9.12.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
-			"integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
 			"dev": true,
 			"requires": {
-				"abab": "^1.0.3",
-				"acorn": "^4.0.4",
-				"acorn-globals": "^3.1.0",
+				"abab": "^2.0.0",
+				"acorn": "^5.5.3",
+				"acorn-globals": "^4.1.0",
 				"array-equal": "^1.0.0",
-				"content-type-parser": "^1.0.1",
 				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": ">= 0.2.37 < 0.3.0",
-				"escodegen": "^1.6.1",
-				"html-encoding-sniffer": "^1.0.1",
-				"nwmatcher": ">= 1.3.9 < 2.0.0",
-				"parse5": "^1.5.1",
-				"request": "^2.79.0",
-				"sax": "^1.2.1",
-				"symbol-tree": "^3.2.1",
-				"tough-cookie": "^2.3.2",
-				"webidl-conversions": "^4.0.0",
-				"whatwg-encoding": "^1.0.1",
-				"whatwg-url": "^4.3.0",
-				"xml-name-validator": "^2.0.1"
+				"cssstyle": "^1.0.0",
+				"data-urls": "^1.0.0",
+				"domexception": "^1.0.1",
+				"escodegen": "^1.9.1",
+				"html-encoding-sniffer": "^1.0.2",
+				"left-pad": "^1.3.0",
+				"nwsapi": "^2.0.7",
+				"parse5": "4.0.0",
+				"pn": "^1.1.0",
+				"request": "^2.87.0",
+				"request-promise-native": "^1.0.5",
+				"sax": "^1.2.4",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^2.3.4",
+				"w3c-hr-time": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.3",
+				"whatwg-mimetype": "^2.1.0",
+				"whatwg-url": "^6.4.1",
+				"ws": "^5.2.0",
+				"xml-name-validator": "^3.0.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+					"dev": true
+				}
 			}
 		},
 		"jsesc": {
 			"version": "1.3.0",
-			"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
 			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
 			"dev": true
 		},
@@ -2987,14 +3601,11 @@
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
-		"json-stable-stringify": {
+		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true,
-			"requires": {
-				"jsonify": "~0.0.0"
-			}
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
@@ -3004,14 +3615,8 @@
 		},
 		"json5": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
 			"dev": true
 		},
 		"jsprim": {
@@ -3035,6 +3640,12 @@
 				"is-buffer": "^1.1.5"
 			}
 		},
+		"kleur": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
+			"integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==",
+			"dev": true
+		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -3043,6 +3654,12 @@
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
+		},
+		"left-pad": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+			"dev": true
 		},
 		"leven": {
 			"version": "2.1.0",
@@ -3062,7 +3679,7 @@
 		},
 		"load-json-file": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
@@ -3071,14 +3688,6 @@
 				"pify": "^2.0.0",
 				"pinkie-promise": "^2.0.0",
 				"strip-bom": "^2.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				}
 			}
 		},
 		"locate-path": {
@@ -3097,6 +3706,12 @@
 			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
 			"dev": true
 		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
+		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3107,9 +3722,9 @@
 			}
 		},
 		"lru-cache": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
@@ -3141,9 +3756,9 @@
 			}
 		},
 		"math-random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
 			"dev": true
 		},
 		"mem": {
@@ -3160,6 +3775,15 @@
 			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
 			"integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
 			"dev": true
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^2.0.1"
+			}
 		},
 		"micromatch": {
 			"version": "2.3.11",
@@ -3214,7 +3838,7 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 			"dev": true
 		},
@@ -3241,7 +3865,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"dev": true,
 			"requires": {
@@ -3249,15 +3873,21 @@
 			}
 		},
 		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+			"dev": true
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 			"dev": true
 		},
 		"nan": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
 			"dev": true,
 			"optional": true
 		},
@@ -3306,6 +3936,12 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3325,9 +3961,9 @@
 			}
 		},
 		"normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.2.tgz",
+			"integrity": "sha512-YcMnjqeoUckXTPKZSAsPjUPLxH85XotbpqK3w4RyCwdFQSU5FxxBys8buehkSfg0j9fKvV1hn7O0+8reEgkAiw==",
 			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
@@ -3360,10 +3996,10 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
 		},
-		"nwmatcher": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+		"nwsapi": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
+			"integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
 			"dev": true
 		},
 		"oauth-sign": {
@@ -3400,6 +4036,12 @@
 				}
 			}
 		},
+		"object-keys": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+			"dev": true
+		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -3415,6 +4057,16 @@
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				}
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
 			}
 		},
 		"object.omit": {
@@ -3453,6 +4105,15 @@
 				"wrappy": "1"
 			}
 		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^1.0.0"
+			}
+		},
 		"optimist": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -3461,6 +4122,14 @@
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+					"dev": true
+				}
 			}
 		},
 		"optionator": {
@@ -3475,19 +4144,11 @@
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2",
 				"wordwrap": "~1.0.0"
-			},
-			"dependencies": {
-				"wordwrap": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-					"dev": true
-				}
 			}
 		},
 		"os-homedir": {
 			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"dev": true
 		},
@@ -3504,14 +4165,8 @@
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
-		},
-		"p-cancelable": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-			"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
 			"dev": true
 		},
 		"p-finally": {
@@ -3544,6 +4199,15 @@
 			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 			"dev": true
 		},
+		"parent-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+			"integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0"
+			}
+		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -3566,9 +4230,9 @@
 			}
 		},
 		"parse5": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-			"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
 			"dev": true
 		},
 		"pascalcase": {
@@ -3585,8 +4249,14 @@
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
 			"dev": true
 		},
 		"path-key": {
@@ -3610,14 +4280,6 @@
 				"graceful-fs": "^4.1.2",
 				"pify": "^2.0.0",
 				"pinkie-promise": "^2.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				}
 			}
 		},
 		"performance-now": {
@@ -3627,9 +4289,9 @@
 			"dev": true
 		},
 		"pify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 			"dev": true
 		},
 		"pinkie": {
@@ -3646,6 +4308,27 @@
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			}
+		},
+		"pluralize": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"dev": true
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
@@ -3666,21 +4349,13 @@
 			"dev": true
 		},
 		"pretty-format": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-			"integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+			"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 			"dev": true,
 			"requires": {
 				"ansi-regex": "^3.0.0",
 				"ansi-styles": "^3.2.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				}
 			}
 		},
 		"private": {
@@ -3689,11 +4364,27 @@
 			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
 			"dev": true
 		},
-		"prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 			"dev": true
+		},
+		"progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true
+		},
+		"prompts": {
+			"version": "0.1.14",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
+			"integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
+			"dev": true,
+			"requires": {
+				"kleur": "^2.0.1",
+				"sisteransi": "^0.1.1"
+			}
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -3702,9 +4393,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
 			"dev": true
 		},
 		"punycode": {
@@ -3786,6 +4477,30 @@
 				}
 			}
 		},
+		"readable-stream": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"realpath-native": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
+			"integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
+			"dev": true,
+			"requires": {
+				"util.promisify": "^1.0.0"
+			}
+		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -3810,6 +4525,12 @@
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
 			}
+		},
+		"regexpp": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+			"dev": true
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -3864,6 +4585,44 @@
 				"tough-cookie": "~2.4.3",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				}
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.13.1"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"dev": true,
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "^1.1.0",
+				"tough-cookie": ">=2.3.3"
 			}
 		},
 		"require-directory": {
@@ -3884,11 +4643,44 @@
 			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
 			"dev": true
 		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"dev": true,
+			"requires": {
+				"resolve-from": "^3.0.0"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
+				}
+			}
+		},
+		"resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true
+		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
+			"requires": {
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
+			}
 		},
 		"ret": {
 			"version": "0.1.15",
@@ -3897,12 +4689,12 @@
 			"dev": true
 		},
 		"rimraf": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "^7.1.3"
 			}
 		},
 		"rsvp": {
@@ -3910,6 +4702,24 @@
 			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
 			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
 			"dev": true
+		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
+			"requires": {
+				"is-promise": "^2.1.0"
+			}
+		},
+		"rxjs": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+			"integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.9.0"
+			}
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
@@ -3919,7 +4729,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
@@ -3988,6 +4798,15 @@
 								"is-extendable": "^0.1.0"
 							}
 						}
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
 					}
 				},
 				"expand-brackets": {
@@ -4225,8 +5044,14 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
 			}
@@ -4304,11 +5129,28 @@
 			"resolved": "https://registry.npmjs.org/simple-markdown/-/simple-markdown-0.4.2.tgz",
 			"integrity": "sha512-lysF/mIJ3Trv/QsxY5Q5XWupVLtyPH6AslxOxscWhUshQNAfHRd7ayuXHlXkXVnujHfIVa0okDw3ZGnzCroO7Q=="
 		},
+		"sisteransi": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
+			"integrity": "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g==",
+			"dev": true
+		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
 			"dev": true
+		},
+		"slice-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+			"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"astral-regex": "^1.0.0",
+				"is-fullwidth-code-point": "^2.0.0"
+			}
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -4326,6 +5168,15 @@
 				"use": "^3.1.0"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -4343,6 +5194,12 @@
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
 				}
 			}
 		},
@@ -4453,9 +5310,9 @@
 			"dev": true
 		},
 		"spdx-correct": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-			"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
@@ -4479,9 +5336,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-			"integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
 			"dev": true
 		},
 		"split-string": {
@@ -4500,9 +5357,9 @@
 			"dev": true
 		},
 		"sshpk": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-			"integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
@@ -4515,6 +5372,12 @@
 				"safer-buffer": "^2.0.2",
 				"tweetnacl": "~0.14.0"
 			}
+		},
+		"stack-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+			"dev": true
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -4537,6 +5400,12 @@
 				}
 			}
 		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"dev": true
+		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -4555,14 +5424,15 @@
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
-			},
-			"dependencies": {
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				}
+			}
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -4572,14 +5442,6 @@
 			"dev": true,
 			"requires": {
 				"ansi-regex": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				}
 			}
 		},
 		"strip-bom": {
@@ -4593,8 +5455,14 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true
 		},
 		"supports-color": {
@@ -4612,6 +5480,18 @@
 			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
 			"dev": true
 		},
+		"table": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.2.2.tgz",
+			"integrity": "sha512-f8mJmuu9beQEDkKHLzOv4VxVYlU68NpdzjbGPl69i4Hx0sTopJuNxuzJd17iV2h24dAfa93u794OnDA5jqXvfQ==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.6.1",
+				"lodash": "^4.17.11",
+				"slice-ansi": "^2.0.0",
+				"string-width": "^2.1.1"
+			}
+		},
 		"test-exclude": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
@@ -4625,11 +5505,32 @@
 				"require-main-filename": "^1.0.1"
 			}
 		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
+		},
 		"throat": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
 			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
 			"dev": true
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "~1.0.2"
+			}
 		},
 		"tmpl": {
 			"version": "1.0.4",
@@ -4686,33 +5587,34 @@
 			}
 		},
 		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"dev": true,
 			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
 			}
 		},
 		"tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-			"dev": true
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
 			"dev": true
 		},
 		"tunnel-agent": {
@@ -4861,6 +5763,22 @@
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
 		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
+			}
+		},
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -4888,6 +5806,15 @@
 				"extsprintf": "^1.2.0"
 			}
 		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"dev": true,
+			"requires": {
+				"browser-process-hrtime": "^0.1.2"
+			}
+		},
 		"walker": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -4909,7 +5836,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -4930,22 +5857,21 @@
 				"iconv-lite": "0.4.24"
 			}
 		},
+		"whatwg-mimetype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+			"dev": true
+		},
 		"whatwg-url": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
-			"integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
 			"dev": true,
 			"requires": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
-			},
-			"dependencies": {
-				"webidl-conversions": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-					"dev": true
-				}
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"which": {
@@ -4964,23 +5890,14 @@
 			"dev": true
 		},
 		"wordwrap": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
 			"dev": true
-		},
-		"worker-farm": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
-			"dev": true,
-			"requires": {
-				"errno": "~0.1.7"
-			}
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
@@ -4988,6 +5905,21 @@
 				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -5001,7 +5933,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
@@ -5016,10 +5948,19 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
 		},
+		"write": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
+			"requires": {
+				"mkdirp": "^0.5.1"
+			}
+		},
 		"write-file-atomic": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+			"integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
@@ -5027,10 +5968,19 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
+		"ws": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+			"dev": true,
+			"requires": {
+				"async-limiter": "~1.0.0"
+			}
+		},
 		"xml-name-validator": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
 			"dev": true
 		},
 		"y18n": {
@@ -5046,86 +5996,29 @@
 			"dev": true
 		},
 		"yargs": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-			"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+			"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0",
-				"cliui": "^3.2.0",
+				"cliui": "^4.0.0",
 				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
 				"get-caller-file": "^1.0.1",
 				"os-locale": "^2.0.0",
-				"read-pkg-up": "^2.0.0",
 				"require-directory": "^2.1.1",
 				"require-main-filename": "^1.0.1",
 				"set-blocking": "^2.0.0",
 				"string-width": "^2.0.0",
 				"which-module": "^2.0.0",
 				"y18n": "^3.2.1",
-				"yargs-parser": "^7.0.0"
-			},
-			"dependencies": {
-				"load-json-file": {
-					"version": "2.0.0",
-					"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"path-type": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-					"dev": true,
-					"requires": {
-						"pify": "^2.0.0"
-					}
-				},
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^2.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^2.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"dev": true,
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
-				}
+				"yargs-parser": "^9.0.2"
 			}
 		},
 		"yargs-parser": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 	"license": "MIT",
 	"private": false,
 	"scripts": {
-		"test": "jest --verbose"
+		"test": "jest --verbose",
+		"lint": "eslint ."
 	},
 	"dependencies": {
 		"highlight.js": "^9.13.1",

--- a/test/discord.test.js
+++ b/test/discord.test.js
@@ -112,4 +112,6 @@ test('spoiler oddities', () => {
 		.toBe('<spoiler>|</spoiler>|');
 	expect(markdown.toHTML('||<a>yay</a>||'))
 		.toBe('<spoiler>&lt;a&gt;yay&lt;/a&gt;</spoiler>');
+	expect(markdown.toHTML('*yay* ||fox||'))
+		.toBe('<em>yay</em> <spoiler>fox</spoiler>');
 })

--- a/test/discord.test.js
+++ b/test/discord.test.js
@@ -89,3 +89,27 @@ test('with discord-only don\'t parse normal stuff', () => {
 	expect(markdown.toHTML('*yay* <@123456>', { discordOnly: true }))
 		.toBe('*yay* @123456');
 });
+
+test('spoilers are parsed correctly', () => {
+	expect(markdown.toHTML('||fox||'))
+		.toBe('<spoiler>fox</spoiler>');
+	expect(markdown.toHTML('|| fox ||'))
+		.toBe('<spoiler> fox </spoiler>');
+	expect(markdown.toHTML('|| fox | bunny ||'))
+		.toBe('<spoiler> fox | bunny </spoiler>');
+	expect(markdown.toHTML('a ||fox|| and a ||bunny||\nlike to ||hop||'))
+		.toBe('a <spoiler>fox</spoiler> and a <spoiler>bunny</spoiler><br>like to <spoiler>hop</spoiler>');
+	expect(markdown.toHTML('this ||fox\nreally likes|| to dig'))
+		.toBe('this <spoiler>fox<br>really likes</spoiler> to dig');
+});
+
+test('spoiler oddities', () => {
+	expect(markdown.toHTML('||||'))
+		.toBe('||||');
+	expect(markdown.toHTML('|| ||'))
+		.toBe('<spoiler> </spoiler>');
+	expect(markdown.toHTML('||||||'))
+		.toBe('<spoiler>|</spoiler>|');
+	expect(markdown.toHTML('||<a>yay</a>||'))
+		.toBe('<spoiler>&lt;a&gt;yay&lt;/a&gt;</spoiler>');
+})

--- a/test/discord.test.js
+++ b/test/discord.test.js
@@ -92,26 +92,26 @@ test('with discord-only don\'t parse normal stuff', () => {
 
 test('spoilers are parsed correctly', () => {
 	expect(markdown.toHTML('||fox||'))
-		.toBe('<spoiler>fox</spoiler>');
+		.toBe('<span class="d-spoiler">fox</span>');
 	expect(markdown.toHTML('|| fox ||'))
-		.toBe('<spoiler> fox </spoiler>');
+		.toBe('<span class="d-spoiler"> fox </span>');
 	expect(markdown.toHTML('|| fox | bunny ||'))
-		.toBe('<spoiler> fox | bunny </spoiler>');
+		.toBe('<span class="d-spoiler"> fox | bunny </span>');
 	expect(markdown.toHTML('a ||fox|| and a ||bunny||\nlike to ||hop||'))
-		.toBe('a <spoiler>fox</spoiler> and a <spoiler>bunny</spoiler><br>like to <spoiler>hop</spoiler>');
+		.toBe('a <span class="d-spoiler">fox</span> and a <span class="d-spoiler">bunny</span><br>like to <span class="d-spoiler">hop</span>');
 	expect(markdown.toHTML('this ||fox\nreally likes|| to dig'))
-		.toBe('this <spoiler>fox<br>really likes</spoiler> to dig');
+		.toBe('this <span class="d-spoiler">fox<br>really likes</span> to dig');
 });
 
 test('spoiler oddities', () => {
 	expect(markdown.toHTML('||||'))
 		.toBe('||||');
 	expect(markdown.toHTML('|| ||'))
-		.toBe('<spoiler> </spoiler>');
+		.toBe('<span class="d-spoiler"> </span>');
 	expect(markdown.toHTML('||||||'))
-		.toBe('<spoiler>|</spoiler>|');
+		.toBe('<span class="d-spoiler">|</span>|');
 	expect(markdown.toHTML('||<a>yay</a>||'))
-		.toBe('<spoiler>&lt;a&gt;yay&lt;/a&gt;</spoiler>');
+		.toBe('<span class="d-spoiler">&lt;a&gt;yay&lt;/a&gt;</span>');
 	expect(markdown.toHTML('*yay* ||fox||'))
-		.toBe('<em>yay</em> <spoiler>fox</spoiler>');
+		.toBe('<em>yay</em> <span class="d-spoiler">fox</span>');
 })

--- a/test/discord.test.js
+++ b/test/discord.test.js
@@ -90,11 +90,6 @@ test('with discord-only don\'t parse normal stuff', () => {
 		.toBe('*yay* <span class="d-mention d-user">@123456</span>');
 });
 
-test('spoilers in a message', () => {
-	expect(markdown.toHTML('This contains {{a spoiler}}'))
-		.toBe('This contains <span class="d-spoiler">a spoiler</span>');
-});
-
 test('spoilers are parsed correctly', () => {
 	expect(markdown.toHTML('||fox||'))
 		.toBe('<spoiler>fox</spoiler>');


### PR DESCRIPTION
The existing code for `some {{spoiler}}` doesn't seem to be what discords markdown for this is.

As of the point of writing this they introduced `some ||spoiler||` with all kind of cases. Currently webbrowser discord just gobbles up the `|`, but android discord makes it a spoiler correctly.

This makes spoilers have the ability to have a custom callback, as, well, each environment may want to treat spoilers differently