### PR TITLE
Fix line-by-line quote parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ markdown.htmlTag = htmlTag;
 const rules = {
 	blockQuote: Object.assign({}, markdown.defaultRules.blockQuote, {
 		match: function(source, state, prevSource) {
-			return !/^$|\n *$/.test(prevSource) || state.inQuote ? null : /^( *>>> ([\s\S]*))|^( *> [^\n]+(\n *> [^\n]+)*\n?)/.exec(source);
+			return !/^$|\n *$/.test(prevSource) || state.inQuote ? null : /^( *>>> ([\s\S]*))|^( *> [^\n]*(\n *> [^\n]*)*\n?)/.exec(source);
 		},
 		parse: function(capture, parse, state) {
 			const all = capture[0];

--- a/test/single.test.js
+++ b/test/single.test.js
@@ -84,6 +84,8 @@ test('Block quotes', () => {
 		.toBe('outside<br><blockquote>inside<br>text<br>&gt; here<br>does not end</blockquote>');
 	expect(markdown.toHTML('>>> test\n```js\ncode```'))
 		.toBe('<blockquote>test<br><pre><code class="hljs js">code</code></pre></blockquote>');
+	expect(markdown.toHTML('> text\n> \n> here'))
+		.toBe('<blockquote>text<br><br>here</blockquote>');
 });
 
 test('don\'t drop arms', () => {


### PR DESCRIPTION
This makes it so block quotes of the following form are correctly parsed:
```
> Lorem ipsum
> 
> dolor sit amet
```
(Note the extra space after the leading angle bracket on the second line). Discord works just like GitHub here and renders it like this:
> Lorem ipsum
> 
> dolor sit amet

That is, lines may be empty except for the leading angle bracket and space.