### PR TITLE
Fix parsing multiple blockquotes and inlineCode syntax error

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,8 +113,11 @@ const rules = {
 	strike: Object.assign({ }, markdown.defaultRules.del, {
 		match: markdown.inlineRegex(/^~~([\s\S]+?)~~(?!_)/),
 	}),
-	inlineCode: Object.assign({ }, markdown.defaultRules.inlineCode {
-		match: source => source = source.trimEnd(), markdown.defaultRules.inlineCode.match.regex.exec(source)
+	inlineCode: Object.assign({ }, markdown.defaultRules.inlineCode, {
+		match: source => markdown.defaultRules.inlineCode.match.regex.exec(source),
+		html: function(node, output, state) {
+			return htmlTag('code', node.content.trim(), null, state);
+		}
 	}),
 	text: Object.assign({ }, markdown.defaultRules.text, {
 		match: source => /^[\s\S]+?(?=[^0-9A-Za-z\s\u00c0-\uffff-]|\n\n|\n|\w+:\S|$)/.exec(source),

--- a/index.js
+++ b/index.js
@@ -39,17 +39,8 @@ const rules = {
 			const removeSyntaxRegex = isBlock ? /^ *>>> ?/ : /^ *> ?/gm;
 			const content = all.replace(removeSyntaxRegex, '');
 
-			state.inQuote = true
-			if (!isBlock)
-				state.inline = true;
-
-			const parsed = parse(content, state);
-
-			state.inQuote = state.inQuote || false;
-			state.inline = state.inline || false;
-
 			return {
-				content: parsed,
+				content: parse(content, Object.assign({}, state, {inQuote: true})),
 				type: 'blockQuote'
 			}
 		}
@@ -116,7 +107,7 @@ const rules = {
 	inlineCode: Object.assign({ }, markdown.defaultRules.inlineCode, {
 		match: source => markdown.defaultRules.inlineCode.match.regex.exec(source),
 		html: function(node, output, state) {
-			return htmlTag('code', node.content.trim(), null, state);
+			return htmlTag('code', markdown.sanitizeText(node.content.trim()), null, state);
 		}
 	}),
 	text: Object.assign({ }, markdown.defaultRules.text, {

--- a/test/single.test.js
+++ b/test/single.test.js
@@ -88,6 +88,8 @@ test('Block quotes', () => {
 		.toBe('<blockquote>test<br><pre><code class="hljs js">code</code></pre></blockquote>');
 	expect(markdown.toHTML('> text\n> \n> here'))
 		.toBe('<blockquote>text<br><br>here</blockquote>');
+	expect(markdown.toHTML('text\n\n> Lorem ipsum\n>> Lorem ipsum\n> Lorem ipsum\n> > Lorem ipsum\n> Lorem ipsum\n\nLorem ipsum\n\n> Lorem ipsum\n\nLorem ipsum\n\n>>> text\ntext\ntext\n'))
+		.toBe('text<br><br><blockquote>Lorem ipsum<br></blockquote>&gt;&gt; Lorem ipsum<br><blockquote>Lorem ipsum<br>&gt; Lorem ipsum<br>Lorem ipsum<br></blockquote><br>Lorem ipsum<br><br><blockquote>Lorem ipsum<br></blockquote><br>Lorem ipsum<br><br><blockquote>text<br>text<br>text<br></blockquote>');
 });
 
 test('don\'t drop arms', () => {


### PR DESCRIPTION
## Summary

This pull request resolves two problems I found in the current `master` code:

  1. The parser handles one blockquote just fine, but if you have multiple blockquotes it only handles the first blockquote.

  2. There's a JavaScript syntax error [on index.js lines 116 - 118](https://github.com/brussell98/discord-markdown/blob/35f7cff5fb9aff1a9c2863e657bfafef39f8314c/index.js#L116-L118). I'm not sure why a syntax error got committed but I tried to fix it.

     - **Note:** currently on the mobile version of Discord, leading and trailing spaces are trimmed from inline code but on the desktop version of Discord they're not trimmed...

## Demonstration of problem

Here's a screenshot from a website I'm developing that uses `discord-markdown`. Only one `blockquote` element is rendered when multiple blockquotes are expected.
  
![image](https://user-images.githubusercontent.com/5068466/73600387-3afbfd00-4504-11ea-86c6-2021bfee2d21.png)

Here's the expected result in Discord itself:

![image](https://user-images.githubusercontent.com/5068466/73600473-50255b80-4505-11ea-9e9f-ebcd277b5383.png)

This pull request fixes this issue. After uninstalling the `discord-markdown` module from my website and reinstalling it from my forked repository, multiple blockquotes are now rendered properly:

![image](https://user-images.githubusercontent.com/5068466/73600438-f4f36900-4504-11ea-98c1-55cebd636e26.png)

## Code explanation

[On line 42](https://github.com/brussell98/discord-markdown/blob/35f7cff5fb9aff1a9c2863e657bfafef39f8314c/index.js#L42) the `state.inQuote` property is set to `true` which not only sets `inQuote` to true when parsing the contents of the blockquote but also when parsing everything after the blockquote.

The [blockquote match function](https://github.com/brussell98/discord-markdown/blob/35f7cff5fb9aff1a9c2863e657bfafef39f8314c/index.js#L34) always returns `null` if `state.inQuote` is true, as such, only one blockquote element can be rendered.

So I took out the lines that directly changed the properties of `state` and instead I passed `Object.assign({}, state, {inQuote: true})` to the second argument of `parse()`.

I also took out the [lines 43 - 44](https://github.com/brussell98/discord-markdown/blob/35f7cff5fb9aff1a9c2863e657bfafef39f8314c/index.js#L43-L44) as [state.inline is already true](https://github.com/brussell98/discord-markdown/blob/35f7cff5fb9aff1a9c2863e657bfafef39f8314c/index.js#L299). Taking out these lines doesn't prevent the tests from passing.