### PR TITLE
Fixes issue #11 (nested ems)

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,15 +110,8 @@ const rules = {
 	em: Object.assign({ }, markdown.defaultRules.em, {
 		parse: function(capture, parse, state) {
 			const parsed = markdown.defaultRules.em.parse(capture, parse, Object.assign({ }, state, { inEmphasis: true }));
-			parsed.inEmphasis = state.inEmphasis || false;
-			return parsed;
+			return state.inEmphasis ? parsed.content : parsed;
 		},
-		html: function(node, output, state) {
-			if (node.inEmphasis) {
-				return output(node.content, state);
-			}
-			return markdown.defaultRules.em.html(node, output, state);
-		}
 	}),
 	strong: markdown.defaultRules.strong,
 	u: markdown.defaultRules.u,

--- a/index.js
+++ b/index.js
@@ -107,7 +107,19 @@ const rules = {
 			return htmlTag('a', output(node.content, state), { href: markdown.sanitizeUrl(node.target) }, state);
 		}
 	}),
-	em: markdown.defaultRules.em,
+	em: Object.assign({ }, markdown.defaultRules.em, {
+		parse: function(capture, parse, state) {
+			const parsed = markdown.defaultRules.em.parse(capture, parse, Object.assign({ }, state, { inEmphasis: true }));
+            parsed.inEmphasis = state.inEmphasis || false;
+            return parsed;
+		},
+		html: function(node, output, state) {
+			if (node.inEmphasis) {
+				return output(node.content, state);
+			}
+			return markdown.defaultRules.em.html(node, output, state);
+		}
+	}),
 	strong: markdown.defaultRules.strong,
 	u: markdown.defaultRules.u,
 	strike: Object.assign({ }, markdown.defaultRules.del, {
@@ -298,6 +310,7 @@ function toHTML(source, options) {
 	const state = {
 		inline: true,
 		inQuote: false,
+		inEmphasis: false,
 		escapeHTML: options.escapeHTML,
 		cssModuleNames: options.cssModuleNames || null
 	};

--- a/index.js
+++ b/index.js
@@ -110,8 +110,8 @@ const rules = {
 	em: Object.assign({ }, markdown.defaultRules.em, {
 		parse: function(capture, parse, state) {
 			const parsed = markdown.defaultRules.em.parse(capture, parse, Object.assign({ }, state, { inEmphasis: true }));
-            parsed.inEmphasis = state.inEmphasis || false;
-            return parsed;
+			parsed.inEmphasis = state.inEmphasis || false;
+			return parsed;
 		},
 		html: function(node, output, state) {
 			if (node.inEmphasis) {

--- a/test/oddities.test.js
+++ b/test/oddities.test.js
@@ -56,3 +56,10 @@ test('Spoiler edge-cases', () => {
 	expect(markdown.toHTML('||||||'))
 		.toBe('<span class="d-spoiler">|</span>|');
 });
+
+test('Nested <em>', () => {
+	expect(markdown.toHTML('_hello world *foo bar* hello world_'))
+		.toBe('<em>hello world foo bar hello world</em>');
+	expect(markdown.toHTML('_hello world *foo __blah__ bar* hello world_'))
+		.toBe('<em>hello world foo <u>blah</u> bar hello world</em>');
+});


### PR DESCRIPTION
Although a nested `<em>` tag shouldn't affect how the rendered markdown looks without any special CSS styling, I think this library should still reflect Discord's parsing behavior as closely as possible.

---

This PR modifies the default rules for `em`:

  - adds state flag `inEmphasis` when parsing contents (flag would still be false if parsing outermost `em`)
  - if `inEmphasis` is true, then the `parse` function returns the parsed node's contents rather than the node itself to exclude the `<em>` tags

Added new tests to `oddities.test.js` to test this behavior.

**Failing tests:** Overall tests may fail due to bugs in the `inlineCode` rule, my other PR should fix those bugs.