### PR TITLE
fix URL of animated emojis

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ const rulesDiscord = {
 		html: function(node, output, state) {
 			return htmlTag('img', '', {
 				class: `d-emoji${node.animated ? ' d-emoji-animated' : ''}`,
-				src: `https://cdn.discordapp.com/emojis/${node.id}.png`,
+				src: `https://cdn.discordapp.com/emojis/${node.id}.${node.animated ? 'gif' : 'png'}`,
 				alt: `:${node.name}:`
 			}, false, state);
 		}


### PR DESCRIPTION
The emoji rule always uses the file extension `.png`, which makes animated emojis appear as static images. This PR changes the extension to `.gif` if the emoji is animated.