### PR TITLE
Added Typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,29 @@
+import * as markdown from 'simple-markdown';
+
+interface DiscordCallback {
+  user?: (id: number) => string;
+  channel?: (id: number) => string;
+  role?: (id: number) => string;
+  everyone?: () => string;
+  here?: () => string;
+}
+
+interface HTMLOptions {
+  embed?: boolean;
+  escapeHTML?: boolean;
+  discordOnly?: boolean;
+  discordCallback: DiscordCallback;
+  cssModuleNames: Record<string, string>;
+}
+
+export function parser(source: string): markdown.SingleASTNode[]
+export function htmlOutput(node: markdown.ASTNode, state?: markdown.OptionalState): unknown;
+export function toHTML(source: string, options?: HTMLOptions): string;
+export function htmlTag(tagName: string, content: string, attributes: Record<string, string>, isClosed?: boolean, state?: markdown.State): string
+
+type MarkdownRules = Record<string, Record<string, unknown>>;
+
+export const rules: MarkdownRules;
+export const rulesDiscordOnly: MarkdownRules;
+export const rulesEmbed: MarkdownRules;
+export const markdownEngine: typeof markdown;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"md"
 	],
 	"main": "index.js",
+	"types": "index.d.ts",
 	"repository": "https://github.com/brussell98/discord-markdown.git",
 	"author": "Brussell (https://brussell.me)",
 	"contributors": [


### PR DESCRIPTION
I used `Record<string, Record<string, unknown>>` for all the rules objects because I thought it would be much too tedious to make everything accurate, but I can go back and make those types stricter if need be.

Closes #23