### PR TITLE
Fix typings for HTMLOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,8 +12,8 @@ interface HTMLOptions {
   embed?: boolean;
   escapeHTML?: boolean;
   discordOnly?: boolean;
-  discordCallback: DiscordCallback;
-  cssModuleNames: Record<string, string>;
+  discordCallback?: DiscordCallback;
+  cssModuleNames?: Record<string, string>;
 }
 
 export function parser(source: string): markdown.SingleASTNode[]


### PR DESCRIPTION
These two attribute are supposed to be optional, judging by the code, they are set default values when omitted.

Otherwise, it makes you update the signature to this in order to avoid linting errors:

```ts
toHTML(value, { embed: true, discordCallback: {}, cssModuleNames: {} }
```