### PR TITLE
Add missing type argument to allow this to work in more environments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ interface HTMLOptions {
 
 export function parser(source: string): markdown.SingleASTNode[]
 export function htmlOutput(node: markdown.ASTNode, state?: markdown.OptionalState): unknown;
-export function toHTML(source: string, options?: HTMLOptions, customParser?: markdown.Parser, customOutput?: markdown.Output): string;
+export function toHTML(source: string, options?: HTMLOptions, customParser?: markdown.Parser, customOutput?: markdown.Output<any>): string;
 export function htmlTag(tagName: string, content: string, attributes: Record<string, string>, isClosed?: boolean, state?: markdown.State): string
 
 type MarkdownRules = Record<string, Record<string, unknown>>;


### PR DESCRIPTION
Some environments (eg Angular) cannot infer the <any> tag. This should allow those environments to run it without modification, and should not break environments that do not require explicit definition.