### PR TITLE
fix(index.d.ts): add type annotation to toHTML

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ interface HTMLOptions {
 
 export function parser(source: string): markdown.SingleASTNode[]
 export function htmlOutput(node: markdown.ASTNode, state?: markdown.OptionalState): unknown;
-export function toHTML(source: string, options?: HTMLOptions, customParser?: markdown.Parser, customOutput?: markdown.Output): string;
+export function toHTML<T=any>(source: string, options?: HTMLOptions, customParser?: markdown.Parser, customOutput?: markdown.Output<T>): string;
 export function htmlTag(tagName: string, content: string, attributes: Record<string, string>, isClosed?: boolean, state?: markdown.State): string
 
 type MarkdownRules = Record<string, Record<string, unknown>>;


### PR DESCRIPTION
This PR adds a type annotation to the `toHTML` method. Fixes #30. Closes #30.